### PR TITLE
fix(infra): pin pnpm/node and freeze install for Vercel

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,4 @@
+registry=https://registry.npmjs.org/
+prefer-frozen-lockfile=true
+strict-peer-dependencies=false
+auto-install-peers=true

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "smh-web-bot",
   "version": "0.1.0",
+ @  "packageManager":@ "pnpm@9.12.0",
+  "engines": { "node": ">=20.9 <21", "pnpm": ">=9" },
+
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
     "build": "next build --turbopack && next-sitemap",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+        "vercel-build": "pnpm install --frozen-lockfile && pnpm build"
   },
   "dependencies": {
     "@ai-sdk/openai": "^2.0.24",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "smh-web-bot",
   "version": "0.1.0",
- @  "packageManager":@ "pnpm@9.12.0",
+
+      "packageManager": "pnpm@9.12.0", 
   "engines": { "node": ">=20.9 <21", "pnpm": ">=9" },
 
   "private": true,

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,1 @@
+{ "buildCommand": "pnpm install --frozen-lockfile && pnpm build" }

--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,1 @@
-{ "buildCommand": "pnpm install --frozen-lockfile && pnpm build" }
+{ "buildCommand": "corepack enable && corepack prepare pnpm@9.12.0 --activate && pnpm install --frozen-lockfile && pnpm build" }


### PR DESCRIPTION
**Changes**:
- **package.json**: Added `packageManager` field pinning `pnpm@9.12.0`, set `engines` to `node >=20.9 <21` and `pnpm >=9`, and added a `vercel-build` script to install dependencies with a frozen lockfile then build.
- **.npmrc**: Created at repository root with a strict registry configuration (`registry=https://registry.npmjs.org/`), enabled frozen lockfile (`prefer-frozen-lockfile=true`), disabled strict peer deps and enabled automatic peer installation to avoid pnpm meta fetch failures.
- **vercel.json**: Added to set the build command to `pnpm install --frozen-lockfile && pnpm build` so Vercel uses the pinned pnpm/Node versions and does not attempt to auto-download mismatched toolchains.

These changes pin the pnpm and Node versions and configure the build to use a frozen lockfile, addressing the ERR_PNPM_META_FETCH_FAIL and registry warnings seen on Vercel. No app code, UI, or component files were touched.

After merging, this PR should produce a green Vercel build. We'll monitor the preview deployment and update if a fallback `corepack` command is needed.
